### PR TITLE
Typo in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY *-setup.sh /
 RUN chmod +x /startup.sh
 COPY configs/postfix /etc/postfix
 COPY configs/dovecot /etc/dovecot
-COPY configs/spamassassin /etc/spamassasin
+COPY configs/spamassassin /etc/spamassassin
 COPY configs/apache2 /etc/apache2/sites-available
 RUN wget http://sourceforge.net/projects/postfixadmin/files/latest/download?source=files -O /postfixadmin.tgz
 RUN tar xf /postfixadmin.tgz 


### PR DESCRIPTION
There is a 's' missing in spamassassin